### PR TITLE
Insert new records with id type of json.Number instead of int64

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -49,7 +49,7 @@ func addDynamicRoutes(router *httprouter.Router) {
 				id++
 			}
 
-			data["id"] = id
+			data["id"] = json.Number(strconv.FormatInt(id, 10))
 
 			dirty = true
 			serverData.AddRecord(itemType, data)


### PR DESCRIPTION
Current implementation adds new records with int64 id
and than fails at retreiving newly added posts:

```
$ curl lok:3000/posts/1
{"author":"Foo","id":1,"title":"Testing"}$ 

$ curl lok:3000/posts -d '{"author":"Foo","title":"Post 2"}'

$ curl lok:3000/posts/2
null$ 
```

While on the server side there is an error:

```
ERRO[0009] ID either not present for record at index %!i(int=1) or it's unknown type
```

By adding some extra debug lines it turned out the difference:

```
  [DEBUG] id: "1" type: json.Number
  [DEBUG] id: 2 type: int64
```

Records read from son file had an id type of son.Number, while newly inserted got int64
